### PR TITLE
Add minimal React scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # testrepo
+
 ## Editing the file
 Its amardown file in theis repository
+
+## React App
+
+This repository now contains a basic React project scaffold located in the `react-app` directory.
+To start developing:
+
+```bash
+cd react-app
+npm install
+env npm start
+```
+
+The `npm install` step will install dependencies defined in `package.json`.

--- a/react-app/.gitignore
+++ b/react-app/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+build/
+.env

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "react-app",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/react-app/public/index.html
+++ b/react-app/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div className="App">
+      <h1>Hello, React!</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/react-app/src/index.css
+++ b/react-app/src/index.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+}

--- a/react-app/src/index.js
+++ b/react-app/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- add minimal React app under `react-app`
- update README with instructions

## Testing
- `npm test --prefix react-app --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849d4fe5f8883328ddd9369f1245b19